### PR TITLE
Revert "Run lints on pull requests"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: lint
-on: pull_request
+on: push
 jobs:
   format:
     name: Check nix file format


### PR DESCRIPTION
This reverts commit 139de1cc84ff781ec0ff79e14393634fb63f12fd.

As it turns out, a better workaround is to [push using SSH deploy
keys](https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#push-using-ssh-deploy-keys).