### PR TITLE
default: Disable the x11 askpass for openssh

### DIFF
--- a/configurations/default.nix
+++ b/configurations/default.nix
@@ -56,6 +56,7 @@
 
   programs = {
     dconf.enable = true;
+    ssh.askPassword = "";
     zsh.enable = true;
   };
 


### PR DESCRIPTION
This caused crashes in stumpwm. Watch NixOS/nixpkgs#25290 for future
changes to how this is disabled.