### PR TITLE
Disable middle click emulation through right + left click

### DIFF
--- a/configurations/default.nix
+++ b/configurations/default.nix
@@ -80,7 +80,10 @@
     xserver = {
       enable = true;
       layout = "us";
-      libinput.enable = true;
+      libinput = {
+        enable = true;
+        middleEmulation = false;
+      };
 
       displayManager = {
         lightdm.enable = true;


### PR DESCRIPTION
No idea why this is even on by default, it's super annoying in
non-laptop use cases.