### PR TITLE
Fix random disappearance of the xauthority file

### DIFF
--- a/configurations/default.nix
+++ b/configurations/default.nix
@@ -76,6 +76,9 @@
 
   sound.enable = true;
 
+  # See NixOS/nixpkgs#116631
+  systemd.tmpfiles.rules = [ "d /run/lightdm 0711 lightdm lightdm -" ];
+
   services = {
     xserver = {
       enable = true;


### PR DESCRIPTION
systemd-tmpfiles will delete anything listed in these rules
periodically if the cleanup period is set. By default this is 0 (see
NixOS/nixpkgs#116631).

lightdm puts xauthority files in this directory if
`user-authority-in-system-dir = true`, so we need this to be set to -
so that they don't disappear randomly.