### PR TITLE
Add various noise-suppression modules

### DIFF
--- a/configurations/yui/default.nix
+++ b/configurations/yui/default.nix
@@ -28,7 +28,19 @@
 
   services.xserver.videoDrivers = [ "nvidia" ];
 
-  hardware.cpu.amd.updateMicrocode = true;
+  hardware = {
+    pulseaudio = {
+      rnnoise-suppression = {
+        enable = true;
+        source =
+          "alsa_input.usb-Blue_Microphones_Blue_Snowball_2029BAA0FBM8-00.analog-stereo";
+        suppression-type = "stereo";
+        voice-threshold = 60;
+      };
+    };
+
+    cpu.amd.updateMicrocode = true;
+  };
 
   sops.secrets.pia = { };
   services.openvpn.pia-servers.netherlands = {

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,5 +1,8 @@
 { lib, pkgs, config, ... }:
 
 {
-  imports = [ ./services/networking/openvpn-pia.nix ];
+  imports = [
+    ./hardware/pulseaudio/echo-canceling.nix
+    ./services/networking/openvpn-pia.nix
+  ];
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./hardware/pulseaudio/echo-canceling.nix
+    ./hardware/pulseaudio/rnnoise-suppression.nix
     ./services/networking/openvpn-pia.nix
   ];
 }

--- a/modules/hardware/pulseaudio/echo-canceling.nix
+++ b/modules/hardware/pulseaudio/echo-canceling.nix
@@ -1,0 +1,103 @@
+{ config, lib, ... }:
+
+with lib;
+
+let cfg = config.hardware.pulseaudio.echo-canceling;
+
+in {
+  options.hardware.pulseaudio.echo-canceling = {
+    enable = mkEnableOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable echo cancellation.
+
+        Source and sink can be determined with `pactl list short
+        sources` and `pactl list short sink` respectively.
+
+        This will create a new, echo-canceled source, which can be
+        either set as default using pulseaudio config or a graphical
+        tool like pavucontrol.
+
+        This will cancel sound coming from the computer's speakers
+        from the microphone input. This also turns on noise
+        suppression and voice detection, so should in general result
+        in a better listening experience.
+      '';
+    };
+
+    source = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        The input source (microphone) whose input to cancel echos
+        for. Required.
+
+        A list of all sources on the system can be determined with
+        `pactl list short sources`.
+      '';
+    };
+
+    sink = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        The output to cancel out of the microphone input.
+
+        A list of all sinks on the system can be determined with
+        `pactl list short sinks`.
+
+        If not specified, this will be an empty dummy sound, resulting
+        in no cancellation. Useful for headphones.
+      '';
+    };
+
+    aec-method = mkOption {
+      type = types.str;
+      default = "webrtc";
+      description = "The aec method to use.";
+    };
+
+    aec-args = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "analog_gain_control=0"
+        "digital_gain_control=1"
+        "experimental_agc=1"
+        "noise_suppression=1"
+        "voice_detection=1"
+        "extended_filter=1"
+      ];
+      description = ''
+        The default arguments to the echo cancellation module.
+
+        These are undocumented upstream, the defaults were taken
+        from the arch wiki [here](https://wiki.archlinux.org/index.php/PulseAudio/Examples).
+      '';
+    };
+  };
+
+  config = (mkIf cfg.enable {
+    hardware.pulseaudio.extraConfig =
+      assert asserts.assertMsg (cfg.source != null)
+        "A source is required for echo cancellation";
+      let
+        aec-args = builtins.concatStringsSep " " cfg.aec-args;
+        module-args = builtins.concatStringsSep " " ([
+          "use_master_format=1"
+          "aec_method=${cfg.aec-method}"
+          ''aec_args="${aec-args}"''
+
+          ''source_master="${cfg.source}"''
+          ''source_name="${cfg.source}.echo-cancel"''
+          ''source_properties="device.description='Echo\-Canceled Input'"''
+        ] ++ (if cfg.sink != null then
+          [ ''sink_master="${cfg.sink}"'' ]
+        else
+          [ ]));
+      in ''
+        # Enable echo cancellation
+        load-module module-echo-cancel ${module-args}
+      '';
+  });
+}

--- a/modules/hardware/pulseaudio/rnnoise-suppression.nix
+++ b/modules/hardware/pulseaudio/rnnoise-suppression.nix
@@ -1,0 +1,103 @@
+{ pkgs, config, lib, ... }:
+
+with lib;
+
+let cfg = config.hardware.pulseaudio.rnnoise-suppression;
+
+in {
+  options.hardware.pulseaudio.rnnoise-suppression = {
+    enable = mkEnableOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable noise suppression with rnnoise.
+      '';
+    };
+
+    source = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        The input source (microphone) whose input to suppress noise
+        on. Required.
+
+        A list of all sources on the system can be determined with
+        `pactl list short sources`.
+      '';
+    };
+
+    suppression-type = mkOption {
+      type = types.enum [ "mono" "stereo" ];
+      default = "mono";
+      description = ''
+        Whether to suppress on a mono or stereo channel. The default
+        is the safe mono, but you likely want stereo.
+      '';
+    };
+
+    voice-threshold = mkOption {
+      type = types.int;
+      default = 50;
+      description = ''
+        The degree of confidence required to detect voice input.
+
+        Upstream recommends 95 as "probably fine", but suggests 50 as
+        a safe default for most microphones.
+      '';
+    };
+  };
+
+  config = (mkIf cfg.enable {
+    hardware.pulseaudio.extraConfig =
+      assert asserts.assertMsg (cfg.source != null)
+        "A source is required for noise suppression.";
+      let
+        number-of-channels =
+          if cfg.suppression-type == "mono" then "1" else "2";
+      in ''
+        # The sink our noise suppression output will go to
+        load-module module-null-sink ${
+          builtins.concatStringsSep " " [
+            "sink_name=${cfg.source}.denoised"
+            ''sink_properties="device.description='Suppressed Microphone'"''
+            "rate=48000"
+          ]
+        }
+
+        # The noise suppression processing plugin
+        load-module module-ladspa-sink ${
+          builtins.concatStringsSep " " [
+            "sink_name=${cfg.source}.raw"
+            ''sink_properties="device.description='Suppression Processor'"''
+            "sink_master=${cfg.source}.denoised"
+            "label=noise_suppressor_${cfg.suppression-type}"
+            "plugin=${pkgs.rnnoise-plugin}/lib/ladspa/librnnoise_ladspa.so"
+            "control=${toString cfg.voice-threshold}"
+          ]
+        }
+
+        # A loopback module to send source sound to the noise suppressor
+        load-module module-loopback ${
+          builtins.concatStringsSep " " [
+            "source=${cfg.source}"
+            "sink=${cfg.source}.raw"
+            "channels=${number-of-channels}"
+            "source_dont_move=true"
+            "sink_dont_move=true"
+          ]
+        }
+
+        # Finally wrap it all back into a source, so that
+        # applications can use the noise-suppressed input
+        load-module module-remap-source ${
+          builtins.concatStringsSep " " [
+            "source_name=${cfg.source}.denoised-source"
+            ''source_properties="device.description='Noise\-Suppressed Input'"''
+            "master=${cfg.source}.denoised.monitor"
+            "channels=${number-of-channels}"
+            "remix=false"
+          ]
+        }
+      '';
+  });
+}


### PR DESCRIPTION
As it turns out, pulseaudio *does* have built-in noise suppression via the echo-cancellation module. It suppresses the annoying broken microphone noise well enough, and has a side benefit of being really useful on laptops whose microphones don't do echo-cancellation by default.

There also exists, however, an [rnnoise plugin](https://github.com/werman/noise-suppression-for-voice) that can be used for AI-based noise suppression with a little bit of mucking around with sources and sinks. This one cancels out *much more*, entirely removing keyboard typing sounds!

This patch adds NixOS modules for both, so that I can pick whichever fits the use case best, and easily switch between them when the need arises.