### PR TITLE
Use latest Linux kernel on yui

### DIFF
--- a/configurations/yui/default.nix
+++ b/configurations/yui/default.nix
@@ -4,7 +4,7 @@
   imports = [ ./hardware-configuration.nix ];
 
   boot = {
-    kernelPackages = lib.mkOverride 99 pkgs.unstable.linuxPackages_5_10;
+    kernelPackages = lib.mkOverride 99 pkgs.unstable.linuxPackages_latest;
 
     initrd = {
       availableKernelModules = [ "hid_roccat_ryos" ];


### PR DESCRIPTION
While stable now also contains the 5.11 kernel, sadly it has an older
nvidia driver which fails to build [see
here](https://www.nvidia.com/download/driverResults.aspx/171392/en-us).

Nonetheless, we should probably switch to 5.11 already, and switch to
stable whenever it receives an nvidia driver that builds.