### PR TITLE
codethink VPN: update resolv.conf after connecting/disconnecting

### DIFF
--- a/configurations/ct-lt-02052/default.nix
+++ b/configurations/ct-lt-02052/default.nix
@@ -48,6 +48,7 @@
           tls-auth /run/secrets/codethink-vpn-static-key
           key-direction 1
         '';
+        updateResolvConf = true;
       };
     };
   };


### PR DESCRIPTION
This ensures that codethink-internal hostnames resolve properly
immediately after configuring.