### PR TITLE
Add missing nvidia exceptions for unfree software

### DIFF
--- a/configurations/yui/default.nix
+++ b/configurations/yui/default.nix
@@ -7,6 +7,9 @@
     builtins.elem (pkgs.lib.getName pkg) [
       # Required to get the steam controller to work (i.e., for hardware.steam-hardware)
       "steam-original"
+      "nvidia-x11"
+      "nvidia-settings"
+      "nvidia-persistenced"
     ];
 
   boot = {


### PR DESCRIPTION
This was missed in #46 (built locally, but not committed).