### PR TITLE
nix: Configure the flake nixpkgs as the nixpkgs in the registry

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,16 @@
             sops-nix.nixosModules.sops
             home-manager.nixosModules.home-manager
 
-            ({ ... }: { nixpkgs.overlays = overlays; })
+            ({ ... }: {
+              nix.registry.nixpkgs = {
+                from = {
+                  id = "nixpkgs";
+                  type = "indirect";
+                };
+                flake = nixpkgs;
+              };
+              nixpkgs.overlays = overlays;
+            })
           ] ++ modules;
 
           # Additional modules with custom configuration options


### PR DESCRIPTION
This avoids downloading a new version of nixpkgs (and potentially some
packages) every time I run a `nix shell`.

This should really be the default, but I guess it's tricky to do as
long as flakes aren't standard.