### PR TITLE
home-manager: Switch to unstable while nix-direnv is backported

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,16 +49,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1622917919,
-        "narHash": "sha256-9gAIwbQyLhK78bEV648k4tfLK6JkYiPk9QdTECpLuOE=",
+        "lastModified": 1624214437,
+        "narHash": "sha256-BtB6k1mQXG/P8MUlNVcuboQqlxlks2H6i5vj2pbGa3Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "148d85ee8303444fb0116943787aa0b1b25f94df",
+        "rev": "cd11c02c286a996ff55010146baecae4c413634f",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-21.05",
         "repo": "home-manager",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     };
 
     home-manager = {
-      url = "github:nix-community/home-manager/release-21.05";
+      url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     dotfiles = {


### PR DESCRIPTION
See nix-community/home-manager#2109 - some blockers on that MR, and
it's been a week, so it will probably take long enough to resolve for
this to make sense.

Sad to drop stable, and this isn't even supported, but also all my
shells are failing :(