### PR TITLE
home-manager: Switch back to 21.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,15 +49,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1624214437,
-        "narHash": "sha256-BtB6k1mQXG/P8MUlNVcuboQqlxlks2H6i5vj2pbGa3Y=",
+        "lastModified": 1624228557,
+        "narHash": "sha256-wwOqe73BsrXfRv1PhyXQFNC8iTET50KvE/HitdkRgxs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cd11c02c286a996ff55010146baecae4c413634f",
+        "rev": "35a24648d155843a4d162de98c17b1afd5db51e4",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "release-21.05",
         "repo": "home-manager",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     };
 
     home-manager = {
-      url = "github:nix-community/home-manager";
+      url = "github:nix-community/home-manager/release-21.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     dotfiles = {


### PR DESCRIPTION
This reverts commit a4ee85afc1cb262746ec5c157e5a36815d5eb04c.

I was a bit too quick with my change, see #54.

Flake input changes:

* Updated 'home-manager': 'github:nix-community/home-manager/148d85ee8303444fb0116943787aa0b1b25f94df' -> 'github:nix-community/home-manager/35a24648d155843a4d162de98c17b1afd5db51e4'