### PR TITLE
Disable systemd's "emergency mode"

### DIFF
--- a/configurations/default.nix
+++ b/configurations/default.nix
@@ -82,8 +82,14 @@
 
   sound.enable = true;
 
-  # See NixOS/nixpkgs#116631
-  systemd.tmpfiles.rules = [ "d /run/lightdm 0711 lightdm lightdm -" ];
+  systemd = {
+    # See NixOS/nixpkgs#116631
+    tmpfiles.rules = [ "d /run/lightdm 0711 lightdm lightdm -" ];
+
+    # My systems never have usable root accounts anyway, so emergency
+    # mode just drops into a shell telling me it can't log into root
+    enableEmergencyMode = false;
+  };
 
   services = {
     xserver = {


### PR DESCRIPTION
This launches if the system fails to boot for some reason; most
commonly because of broken mount configuration.

The mode cannot be used with a disabled root account anyway, and since
I never set root passwords on my machine, it's entirely useless.