### PR TITLE
yui: Enable nvidia KMS

### DIFF
--- a/configurations/yui/default.nix
+++ b/configurations/yui/default.nix
@@ -47,6 +47,7 @@
   services.xserver.videoDrivers = [ "nvidia" ];
 
   hardware = {
+    nvidia.modesetting.enable = true;
     steam-hardware.enable = true;
     cpu.amd.updateMicrocode = true;
   };


### PR DESCRIPTION
This is currently only using the kernel command line, and therefore
not set during the stage 1 init phase - adding the nvidia kernel
modules to `boot.kernelModules` may be necessary for plymouth password
entry in the future.