### PR TITLE
Update dotfiles to fix projectile checksum

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -28,17 +28,31 @@ jobs:
           git-committer-email: tm@tlater.net
       - name: Build reference pre-update system to compare to
         run: nix build -o before-update .#nixosConfigurations.yui.config.system.build.toplevel
+        # We want to continue even if this errors, because if the
+        # current state fails to build that means one of our inputs
+        # changed a tarball or their mirror disappeared, which the
+        # update is likely to fix.
+        #
+        # This is frequent because elpa doesn't seem to care about
+        # keeping tarballs available.
+        continue-on-error: true
       - name: Update flake inputs
         run: nix flake update
       - name: Build system to compare to pre-update system
         run: nix build -o after-update .#nixosConfigurations.yui.config.system.build.toplevel
       - name: Create version diff
         run: nix run --no-write-lock-file gitlab:khumba/nvd -- diff before-update after-update > version-diff
+        # If we don't have a before-update state, this will fail.
+        continue-on-error: true
       - name: Clean symlinks we don't want to commit
         run: rm before-update after-update
       - name: Commit changes
         run: |
-          git commit -am 'flake.lock: Update' -m '' -m "$(cat version-diff)"
+          if [ -r version-diff ]; then
+              git commit -am 'flake.lock: Update' -m '' -m "$(cat version-diff)"
+          else
+              git commit -am 'flake.lock: Update' -m '' -m 'A dependency project resulted in a non-reproducible build, so version information cannot be shown.'
+          fi
       - name: Clean up uncommitted changes
         run: git clean -fxd
       - uses: peter-evans/create-pull-request@v3

--- a/flake.lock
+++ b/flake.lock
@@ -15,11 +15,11 @@
         "nvfetcher": "nvfetcher"
       },
       "locked": {
-        "lastModified": 1643691194,
-        "narHash": "sha256-58RFmOEFGLHqdDko+J14oL0NL06nkNc1fZtV+9dpsMw=",
+        "lastModified": 1645019809,
+        "narHash": "sha256-WhOOMwWjrb3gX44g/prLqsASaUmzR2SSxDM/E/C65kI=",
         "owner": "tlater",
         "repo": "dotfiles",
-        "rev": "6be1837235b21d07fc5d98bc7dffdc34c4b772c4",
+        "rev": "a6a2988db1537ef3b0eb8f96cc92c8abf142f6b8",
         "type": "github"
       },
       "original": {
@@ -114,11 +114,11 @@
     },
     "nurpkgs": {
       "locked": {
-        "lastModified": 1643420268,
-        "narHash": "sha256-8DgJ0JCbYA6TUoNL07cxC9Z5VZ7H+scP/FYy2bEtwd4=",
+        "lastModified": 1644026416,
+        "narHash": "sha256-njtANY2hAJIWh47bkht+geKEECOtaowdh7wNEuNOnR0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cfc57453ec9ba8efdae6eaad181f3279836f01ee",
+        "rev": "943b303999e2e326763dbf518482633d53199f74",
         "type": "github"
       },
       "original": {
@@ -131,18 +131,20 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": [
+          "dotfiles",
           "flake-utils"
         ],
         "nixpkgs": [
+          "dotfiles",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1642903446,
-        "narHash": "sha256-9G1V0NYpQZgr4chuS/L3p94M06B+sUQBAIbi3l4mCIo=",
+        "lastModified": 1644009273,
+        "narHash": "sha256-UAP6LeazORZfr4bEQEYcndkZqxiEAz1tE4wx+/sSlq8=",
         "owner": "berberman",
         "repo": "nvfetcher",
-        "rev": "58d296aafd6e3e979b6bed56f08d286a416e7718",
+        "rev": "e1343bd545a4b01b8cffea85f5748c04eb65a9dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
See tlater/dotfiles#149. This caused update actions to fail (because
the current state no longer builds), which means that the pre-update
state couldn't be reproduced so no update info can be shown.

This also finally fixes the bit of CI that turns this into failures in
the first place.